### PR TITLE
Add Sudoku board logic with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run --coverage"
-    "e2e": "playwright test"
+    "test": "vitest run --coverage",
+    "e2e": "playwright test",
     "lint": "eslint 'src/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts'"
   },

--- a/src/__tests__/Board.test.ts
+++ b/src/__tests__/Board.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../logic/Board'
+
+describe('Board', () => {
+  it('isLegal returns true on empty board', () => {
+    const b = new Board()
+    expect(b.isLegal(0, 0, 1)).toBe(true)
+  })
+
+  it('place updates grid when move is legal', () => {
+    const b = new Board()
+    expect(b.place(0, 0, 2)).toBe(true)
+    expect(b.grid[0][0]).toBe(2)
+  })
+
+  it('allows placing same number again', () => {
+    const b = new Board()
+    b.place(1, 1, 3)
+    expect(b.place(1, 1, 3)).toBe(true)
+  })
+
+  it('clone produces independent copy', () => {
+    const b = new Board()
+    b.place(2, 2, 4)
+    const c = b.clone()
+    c.place(2, 3, 5)
+    expect(b.grid[2][3]).toBe(0)
+    expect(c.grid[2][3]).toBe(5)
+  })
+
+  it('detects row conflict', () => {
+    const b = new Board()
+    b.place(0, 0, 1)
+    expect(b.isLegal(0, 1, 1)).toBe(false)
+  })
+
+  it('detects column conflict', () => {
+    const b = new Board()
+    b.place(0, 0, 2)
+    expect(b.isLegal(1, 0, 2)).toBe(false)
+  })
+
+  it('detects subgrid conflict', () => {
+    const b = new Board()
+    b.place(1, 1, 3)
+    expect(b.isLegal(2, 2, 3)).toBe(false)
+  })
+
+  it('cannot override cell with different number', () => {
+    const b = new Board()
+    b.place(0, 0, 4)
+    expect(b.place(0, 0, 5)).toBe(false)
+  })
+})

--- a/src/logic/Board.ts
+++ b/src/logic/Board.ts
@@ -1,0 +1,40 @@
+export class Board {
+  grid: number[][];
+
+  constructor(grid?: number[][]) {
+    if (grid) {
+      this.grid = grid.map(row => [...row]);
+    } else {
+      this.grid = Array.from({ length: 9 }, () => Array(9).fill(0));
+    }
+  }
+
+  isLegal(r: number, c: number, n: number): boolean {
+    if (r < 0 || r > 8 || c < 0 || c > 8) return false;
+    if (n < 1 || n > 9) return false;
+    const current = this.grid[r][c];
+    if (current !== 0 && current !== n) return false;
+    for (let i = 0; i < 9; i += 1) {
+      if (i !== c && this.grid[r][i] === n) return false;
+      if (i !== r && this.grid[i][c] === n) return false;
+    }
+    const startRow = Math.floor(r / 3) * 3;
+    const startCol = Math.floor(c / 3) * 3;
+    for (let i = startRow; i < startRow + 3; i += 1) {
+      for (let j = startCol; j < startCol + 3; j += 1) {
+        if ((i !== r || j !== c) && this.grid[i][j] === n) return false;
+      }
+    }
+    return true;
+  }
+
+  place(r: number, c: number, n: number): boolean {
+    if (!this.isLegal(r, c, n)) return false;
+    this.grid[r][c] = n;
+    return true;
+  }
+
+  clone(): Board {
+    return new Board(this.grid);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `Board` class for Sudoku logic
- add vitest unit tests for `Board`
- fix minor typo in `package.json` scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417dca03b8832a9c08ab5c8a929ed6