### PR TITLE
Add deterministic RNG helper

### DIFF
--- a/src/utils/rng.ts
+++ b/src/utils/rng.ts
@@ -1,0 +1,13 @@
+export function mulberry32(seed: number): () => number {
+  let t = seed;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function randInt(rng: () => number, min: number, max: number): number {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}


### PR DESCRIPTION
## Summary
- provide utils/rng.ts with mulberry32 seedable RNG
- helper for integer ranges

## Testing
- `npx eslint --config .eslintrc.cjs 'src/**/*.ts'` *(fails: ESLint couldn't find config)*
- `CI=1 npx vitest run --coverage` *(fails: error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68417dd5546c832aaf21fc793a63208e