### PR TITLE
Add DiceService with basic roll function

### DIFF
--- a/src/logic/DiceService.test.ts
+++ b/src/logic/DiceService.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import DiceService from './DiceService';
+
+describe('DiceService', () => {
+  it('rolls n dice using the rng function', () => {
+    const values = [0, 0.5, 0.999];
+    let idx = 0;
+    const rng = () => values[idx++];
+    const service = new DiceService(rng);
+
+    const result = service.roll(3);
+
+    expect(result).toEqual([1, 4, 6]);
+  });
+});

--- a/src/logic/DiceService.ts
+++ b/src/logic/DiceService.ts
@@ -1,0 +1,17 @@
+export type RandomFn = () => number;
+
+export default class DiceService {
+  private readonly rng: RandomFn;
+
+  constructor(rng: RandomFn) {
+    this.rng = rng;
+  }
+
+  roll(n: number): number[] {
+    const results: number[] = [];
+    for (let i = 0; i < n; i += 1) {
+      results.push(Math.floor(this.rng() * 6) + 1);
+    }
+    return results;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DiceService` for rolling dice with a custom RNG
- add unit test for the service

## Testing
- `npx vitest run` *(fails: expected "," in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68417ddad334832a9c8384e41f82082d